### PR TITLE
Add message text to speech

### DIFF
--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -279,21 +279,22 @@ namespace Ship {
         WmApi->set_keyboard_callbacks(Window::KeyDown, Window::KeyUp, Window::AllKeysUp);
     }
 
-    void task1(const char textToRead[])
+    void task1(const std::string & textToRead)
     {
         const int w = 512;
         int* wp = const_cast <int*> (&w);
-        *wp = strlen(textToRead);
+        *wp = strlen(textToRead.c_str());
 
         wchar_t wtext[w];
-        mbstowcs(wtext, textToRead, strlen(textToRead) + 1);
+        mbstowcs(wtext, textToRead.c_str(), strlen(textToRead.c_str()) + 1);
 
         pVoice->Speak(wtext, SPF_IS_XML | SPF_ASYNC | SPF_PURGEBEFORESPEAK, NULL);
     }
 
     void Window::ReadText(const char textToRead[])
     {
-        std::thread t1(task1, textToRead);
+        std::string textCopy(textToRead);
+        std::thread t1(task1, textCopy);
         t1.detach();
     }
 

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -118,10 +118,10 @@ s16 sOcarinaNoteCEnvR;
 s16 sOcarinaNoteCEnvB;
 s16 sOcarinaNoteCEnvG;
 
-static u8 ttsHasNewMessage;
-static u8 ttsHasMessage;
-static s8 ttsCurrentChoice;
-static u8 ttsMessageBuf[256];
+static u8 sTtsHasNewMessage;
+static u8 sTtsHasMessage;
+static s8 sTtsCurrentChoice;
+static u8 sTtsMessageBuf[256];
 
 void Message_ResetOcarinaNoteState(void) {
     R_OCARINA_NOTES_YPOS(0) = 189;
@@ -3048,22 +3048,22 @@ void Message_TTS_Update(GlobalContext* globalCtx) {
 
     if (msgCtx->msgMode == MSGMODE_TEXT_NEXT_MSG || msgCtx->msgMode == MSGMODE_DISPLAY_SONG_PLAYED_TEXT_BEGIN ||
         (msgCtx->msgMode == MSGMODE_TEXT_CONTINUING && msgCtx->stateTimer == 1)) {
-        ttsHasNewMessage = 1;
+        sTtsHasNewMessage = 1;
     } else if (msgCtx->msgMode == MSGMODE_TEXT_DISPLAYING || msgCtx->msgMode == MSGMODE_OCARINA_STARTING ||
                msgCtx->msgMode == MSGMODE_OCARINA_PLAYING || msgCtx->msgMode == MSGMODE_TEXT_AWAIT_NEXT ||
                msgCtx->msgMode == MSGMODE_TEXT_DONE || msgCtx->msgMode == MSGMODE_DISPLAY_SONG_PLAYED_TEXT ||
                msgCtx->msgMode == MSGMODE_TEXT_DELAYED_BREAK) {
-        if (ttsHasNewMessage == 1) {
-            ttsHasNewMessage = 0;
-            ttsHasMessage = 1;
-            ttsCurrentChoice = 0;
+        if (sTtsHasNewMessage == 1) {
+            sTtsHasNewMessage = 0;
+            sTtsHasMessage = 1;
+            sTtsCurrentChoice = 0;
 
             u32 size = msgCtx->decodedTextLen;
-            Message_TTS_Decode(msgCtx->msgBufDecoded, ttsMessageBuf, 0, size);
-            OTRTextToSpeechCallback(ttsMessageBuf);
+            Message_TTS_Decode(msgCtx->msgBufDecoded, sTtsMessageBuf, 0, size);
+            OTRTextToSpeechCallback(sTtsMessageBuf);
         } else if (msgCtx->msgMode == MSGMODE_TEXT_DONE && msgCtx->choiceNum > 0 &&
-                   msgCtx->choiceIndex != ttsCurrentChoice) {
-            ttsCurrentChoice = msgCtx->choiceIndex;
+                   msgCtx->choiceIndex != sTtsCurrentChoice) {
+            sTtsCurrentChoice = msgCtx->choiceIndex;
             u32 startOffset = 0;
             u32 endOffset = 0;
             while (startOffset < msgCtx->decodedTextLen) {
@@ -3095,14 +3095,14 @@ void Message_TTS_Update(GlobalContext* globalCtx) {
 
                 if (startOffset < msgCtx->decodedTextLen && startOffset != endOffset) {
                     u32 size = endOffset - startOffset;
-                    Message_TTS_Decode(msgCtx->msgBufDecoded, ttsMessageBuf, startOffset, size);
-                    OTRTextToSpeechCallback(ttsMessageBuf);
+                    Message_TTS_Decode(msgCtx->msgBufDecoded, sTtsMessageBuf, startOffset, size);
+                    OTRTextToSpeechCallback(sTtsMessageBuf);
                 }
             }
         }
-    } else if (ttsHasMessage == 1) {
-        ttsHasMessage = 0;
-        ttsHasNewMessage = 0;
+    } else if (sTtsHasMessage == 1) {
+        sTtsHasMessage = 0;
+        sTtsHasNewMessage = 0;
         OTRTextToSpeechCallback(""); // cancel current speech
     }
 }

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -3017,7 +3017,7 @@ void Message_TTS_Decode(u8* srcBuf, u8* dstBuf, u32 srcOffset, u32 size) {
 
         if (currChar < ' ') {
             switch (currChar) {
-                case CTRL_NEWLINE:
+                case MESSAGE_NEWLINE:
                     dstBuf[dstIdx++] = ' ';
                     break;
                 case MESSAGE_COLOR:
@@ -3030,6 +3030,7 @@ void Message_TTS_Decode(u8* srcBuf, u8* dstBuf, u32 srcOffset, u32 size) {
                     break;
                 case MESSAGE_FADE2:
                 case MESSAGE_SFX:
+                case MESSAGE_TEXTID:
                     i += 2;
                     break;
                 default:

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -3104,7 +3104,10 @@ void Message_TTS_Update(GlobalContext* globalCtx) {
     } else if (sTtsHasMessage == 1) {
         sTtsHasMessage = 0;
         sTtsHasNewMessage = 0;
-        OTRTextToSpeechCallback(""); // cancel current speech
+        if (msgCtx->decodedTextLen < 3 || (msgCtx->msgBufDecoded[msgCtx->decodedTextLen - 2] != MESSAGE_FADE &&
+                                           msgCtx->msgBufDecoded[msgCtx->decodedTextLen - 3] != MESSAGE_FADE2)) {
+            OTRTextToSpeechCallback(""); // cancel current speech (except for faded out messages)
+        }
     }
 }
 


### PR DESCRIPTION
This adds a new message update function to send TTS commands based on the global message state. It works with all of the messages I've tested but currently non-ASCII characters are not spoken correctly e.g. extended charset/accents or controller button icons.

It can be enabled with the `gMessageTTS` setting.