### PR TITLE
Aiming cues for ranged items

### DIFF
--- a/soh/include/z64collision_check.h
+++ b/soh/include/z64collision_check.h
@@ -269,7 +269,8 @@ typedef enum {
     /* 4 */ ELEMTYPE_UNK4,
     /* 5 */ ELEMTYPE_UNK5,
     /* 6 */ ELEMTYPE_UNK6,
-    /* 7 */ ELEMTYPE_UNK7
+    /* 7 */ ELEMTYPE_UNK7,
+    /* 8 */ ELEMTYPE_SENSING
 } ElementType;
 
 #define AT_NONE 0 // No flags set. Cannot have AT collisions when set as AT

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -24,6 +24,7 @@ void BootCommands_Init()
     CVar_RegisterS32("gDisableLOD", 0);
     CVar_RegisterS32("gDebugEnabled", 0);
     CVar_RegisterS32("gPauseLiveLink", 0);
+    CVar_RegisterS32("gAimAudioCues", 0);
 }
 
 //void BootCommands_ParseBootArgs(char* str)

--- a/soh/src/code/z_collision_check.c
+++ b/soh/src/code/z_collision_check.c
@@ -1702,23 +1702,25 @@ s32 CollisionCheck_SetATvsAC(GlobalContext* globalCtx, Collider* at, ColliderInf
             at->actor->colChkInfo.atHitEffect = acInfo->bumper.effect;
         }
     }
-    ac->acFlags |= AC_HIT;
-    ac->ac = at->actor;
-    acInfo->acHit = at;
-    acInfo->acHitInfo = atInfo;
-    acInfo->bumperFlags |= BUMP_HIT;
-    if (ac->actor != NULL) {
-        ac->actor->colChkInfo.acHitEffect = atInfo->toucher.effect;
-    }
-    acInfo->bumper.hitPos.x = hitPos->x;
-    acInfo->bumper.hitPos.y = hitPos->y;
-    acInfo->bumper.hitPos.z = hitPos->z;
-    if (!(atInfo->toucherFlags & TOUCH_AT_HITMARK) && ac->colType != COLTYPE_METAL && ac->colType != COLTYPE_WOOD &&
-        ac->colType != COLTYPE_HARD) {
-        acInfo->bumperFlags |= BUMP_DRAW_HITMARK;
-    } else {
-        CollisionCheck_HitEffects(globalCtx, at, atInfo, ac, acInfo, hitPos);
-        atInfo->toucherFlags |= TOUCH_DREW_HITMARK;
+    if (atInfo->elemType != ELEMTYPE_SENSING) {
+        ac->acFlags |= AC_HIT;
+        ac->ac = at->actor;
+        acInfo->acHit = at;
+        acInfo->acHitInfo = atInfo;
+        acInfo->bumperFlags |= BUMP_HIT;
+        if (ac->actor != NULL) {
+            ac->actor->colChkInfo.acHitEffect = atInfo->toucher.effect;
+        }
+        acInfo->bumper.hitPos.x = hitPos->x;
+        acInfo->bumper.hitPos.y = hitPos->y;
+        acInfo->bumper.hitPos.z = hitPos->z;
+        if (!(atInfo->toucherFlags & TOUCH_AT_HITMARK) && ac->colType != COLTYPE_METAL && ac->colType != COLTYPE_WOOD &&
+            ac->colType != COLTYPE_HARD) {
+            acInfo->bumperFlags |= BUMP_DRAW_HITMARK;
+        } else {
+            CollisionCheck_HitEffects(globalCtx, at, atInfo, ac, acInfo, hitPos);
+            atInfo->toucherFlags |= TOUCH_DREW_HITMARK;
+        }
     }
     return 1;
 }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9363,6 +9363,10 @@ void Player_InitCommon(Player* this, GlobalContext* globalCtx, FlexSkeletonHeade
     Collider_SetQuad(globalCtx, &this->swordQuads[1], &this->actor, &D_80854650);
     Collider_InitQuad(globalCtx, &this->shieldQuad);
     Collider_SetQuad(globalCtx, &this->shieldQuad, &this->actor, &D_808546A0);
+
+    if (CVar_GetS32("gAimAudioCues", 0)) {
+        Player_InitAimCueCollision(this, globalCtx);
+    }
 }
 
 static void (*D_80854738[])(GlobalContext* globalCtx, Player* this) = {
@@ -10723,6 +10727,10 @@ void Player_UpdateCommon(Player* this, GlobalContext* globalCtx, Input* input) {
 
     Collider_ResetQuadAC(globalCtx, &this->shieldQuad.base);
     Collider_ResetQuadAT(globalCtx, &this->shieldQuad.base);
+
+    if (CVar_GetS32("gAimAudioCues", 0)) {
+        Player_UpdateAimCue(this, globalCtx);
+    }
 }
 
 static Vec3f D_80854838 = { 0.0f, 0.0f, -30.0f };


### PR DESCRIPTION
Adds audio cues when aiming at/near enemies or hookshot-able surfaces. Enabled with the `gAimAudioCues` option.