### PR TITLE
Add option to allow targeting more actor types

### DIFF
--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -24,6 +24,7 @@ void BootCommands_Init()
     CVar_RegisterS32("gDisableLOD", 0);
     CVar_RegisterS32("gDebugEnabled", 0);
     CVar_RegisterS32("gPauseLiveLink", 0);
+    CVar_RegisterS32("gMoreTargets", 0);
 }
 
 //void BootCommands_ParseBootArgs(char* str)

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1789,8 +1789,33 @@ u32 func_8002F090(Actor* actor, f32 arg1) {
     return arg1 < D_80115FF8[actor->targetMode].rangeSq;
 }
 
+s32 Actor_IsTargetable(Actor* actor, Player* player) {
+    s32 targetMode = CVar_GetS32("gMoreTargets", 0);
+
+    if ((actor->update == NULL) || ((Player*)actor == player)) {
+        return false;
+    }
+
+    if (targetMode == 99) {
+        return true;
+    } else if (targetMode == 2) {
+        return CHECK_FLAG_ALL(actor->flags, ACTOR_FLAG_0) ||
+            actor->category == ACTORCAT_CHEST ||
+            actor->category == ACTORCAT_SWITCH ||
+            actor->id == ACTOR_EN_SW || actor->id == ACTOR_BOSS_GANON ||
+            actor->id == ACTOR_OBJ_HSBLOCK || actor->id == ACTOR_OBJ_SYOKUDAI;
+    } else if (targetMode == 1) {
+        return CHECK_FLAG_ALL(actor->flags, ACTOR_FLAG_0) ||
+            actor->category == ACTORCAT_CHEST ||
+            actor->category == ACTORCAT_SWITCH;
+    } else {
+        //original/default
+        return CHECK_FLAG_ALL(actor->flags, ACTOR_FLAG_0);
+    }
+}
+
 s32 func_8002F0C8(Actor* actor, Player* player, s32 flag) {
-    if ((actor->update == NULL) || !(actor->flags & ACTOR_FLAG_0)) {
+    if (!Actor_IsTargetable(actor, player)) {
         return true;
     }
 
@@ -3227,7 +3252,7 @@ void func_800328D4(GlobalContext* globalCtx, ActorContext* actorCtx, Player* pla
     sp84 = player->unk_664;
 
     while (actor != NULL) {
-        if ((actor->update != NULL) && ((Player*)actor != player) && CHECK_FLAG_ALL(actor->flags, ACTOR_FLAG_0)) {
+        if (Actor_IsTargetable(actor, player)) {
 
             // This block below is for determining the closest actor to player in determining the volume
             // used while playing enemy bgm music


### PR DESCRIPTION
The setting `gMoreTargets` can be set to multiple options to choose between different targeting modes. This implementation changes the targeting logic based on the targeting mode rather than changing e.g. the actor data (actor flag 0).