### PR TITLE
TWEAK: Player Life Meter adjustement

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Anchor.cpp
@@ -914,6 +914,11 @@ const ImVec4 GREEN = ImVec4(0.5f, 1.0f, 0.5f, 1.0f);
 
 bool heartTexturesLoaded = false;
 
+bool IsValidSave() {
+    bool validSave = gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2;
+    return validSave;
+}
+
 const char* heartTextureNames[16] = {
     "Heart_Full",          "Heart_One_Fourth",    "Heart_One_Fourth",    "Heart_One_Fourth",
     "Heart_One_Fourth",    "Heart_One_Fourth",    "Heart_Half",          "Heart_Half",
@@ -1034,7 +1039,7 @@ void AnchorPlayerLocationWindow::DrawElement() {
                 }
                 ImGui::PopStyleVar();
             }
-            if (gPlayState != NULL && client.scene != SCENE_GROTTOS && client.scene != SCENE_ID_MAX && CVarGetInteger("gAnchorPlayerHealth", 0) != 0) {
+            if (IsValidSave() && CVarGetInteger("gAnchorPlayerHealth", 0) != 0) {
                 DisplayLifeMeter(client);
             }
         }


### PR DESCRIPTION
Now display in grotto an ttrigger when save files 1 to 3 are done

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/907324503.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/907324506.zip)
  - [soh-linux-performance.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/907324507.zip)
  - [soh-mac.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/907324508.zip)
  - [soh-switch.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/907324509.zip)
  - [soh-wiiu.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/907324510.zip)
  - [soh-windows.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/907324511.zip)
<!--- section:artifacts:end -->