### PR TITLE
ADD: Magic bar on display info and a separator

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -182,6 +182,10 @@ typedef struct {
     u8 damageValue;
     s16 playerHealth;
     s16 playerHealthCapacity;
+    s16 playerMagic;
+    s16 playerMagicCapacity;
+    s16 isPlayerMagicAcquired;
+    s16 isDoubleMagicAcquired;
     s32 strengthValue;
     f32 yOffset;
     u8 currentMask;

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1421,7 +1421,7 @@ bool isStringEmpty(std::string str) {
 }
 
 #ifdef ENABLE_REMOTE_CONTROL
-static const char* anchorPlayerHealth[4] = { "Disabled", "Numeric", "Hearts", "Numeric + Hearts" };
+static const char* anchorPlayerHealth[4] = { "Disabled", "Numeric", "Hearts and Magic", "Numeric + Hearts and Magic" };
 
 void DrawRemoteControlMenu() {
     if (ImGui::BeginMenu("Network")) {


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/913153883.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/913153884.zip)
  - [soh-linux-performance.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/913153885.zip)
  - [soh-mac.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/913153886.zip)
  - [soh-switch.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/913153887.zip)
  - [soh-wiiu.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/913153888.zip)
  - [soh-windows.zip](https://nightly.link/MelonSpeedruns/Shipwright/actions/artifacts/913153889.zip)
<!--- section:artifacts:end -->